### PR TITLE
Add functional LogicOperator impl

### DIFF
--- a/execution_behaviour/behavioral/logic_executor.go
+++ b/execution_behaviour/behavioral/logic_executor.go
@@ -2,6 +2,7 @@ package behavioral
 
 import (
 	"context"
+
 	"github.com/Shopify/sarama"
 )
 
@@ -10,3 +11,13 @@ import (
 type LogicOperator interface {
 	Operate(ctx context.Context, message *sarama.ConsumerMessage) error
 }
+
+// LogicOperatorFunc functional implementation of the LogicOperator interface
+type LogicOperatorFunc func(ctx context.Context, message *sarama.ConsumerMessage) error
+
+func (fn LogicOperatorFunc) Operate(ctx context.Context, message *sarama.ConsumerMessage) error {
+	return fn(ctx, message)
+}
+
+// type-check
+var _ LogicOperator = (LogicOperatorFunc)(nil)


### PR DESCRIPTION
Add functional implemention of the LogicOperator interface that extends the usage of interface like [http.Handler](https://pkg.go.dev/net/http#Handler) and [http.HandlerFunc ](https://pkg.go.dev/net/http#HandlerFunc.ServeHTTP)