### PR TITLE
halt consume processes after unsubscription

### DIFF
--- a/remote_consumer_test.go
+++ b/remote_consumer_test.go
@@ -48,7 +48,8 @@ func (s *testKafkaSuite) Test_consume_when_a_message_sent_to_local() {
 		Topic: topicParams.ErrorTopic,
 	})
 
-	testConsumer, _ := kafka_wrapper.NewRemoteConsumer(remoteConnectionParams, localConnectionParams)
+	testConsumer, err := kafka_wrapper.NewRemoteConsumer(remoteConnectionParams, localConnectionParams)
+	assert.NoError(err, "NewRemoteConsumer should not error")
 	testConsumer.SubscribeToTopic(topicParams, test_utils.NewEventHandler(messageChn))
 	receivedMessage = <-messageChn
 


### PR DESCRIPTION
# Halt Consume Processes After Unsubscription  

## Description  
This PR fixes an issue where the consumer process continues running after calling `Unsubscribe`, causing repeated error messages. Now, the consumer properly halts all processes when unsubscribed, preventing unnecessary logs and potential resource leaks.  

## Changes  
- Ensures the `Consume` loop stops after unsubscription.  
- Properly cancels the context to terminate goroutines.  

## Impact  
This prevents unnecessary error logs and improves the stability of the consumer lifecycle.  

## Testing  
- Manually verified that consuming stops after calling `Unsubscribe`.  
- Added/updated relevant test cases.  
